### PR TITLE
Update contributing.mdx

### DIFF
--- a/app/pages/docs/contributing.mdx
+++ b/app/pages/docs/contributing.mdx
@@ -21,7 +21,7 @@ Issues with the label
 [`status/ready-to-work-on`](https://github.com/blitz-js/blitz/labels/status%2Fready-to-work-on)
 are the best place to start.
 
-We also label issues as `good first issue` and `good second issue` when
+We also label issues as [`good first issue`](https://github.com/blitz-js/blitz/labels/good%20first%20issue) and [`good second issue`](https://github.com/blitz-js/blitz/labels/good%20second%20issue) when
 appropriate.
 
 If you find one that looks interesting and no one else is already working


### PR DESCRIPTION
Fixed the redirect links for the "blitz-js/blitz", fixed link of `good first issue` and `good second issue`.